### PR TITLE
fix: cambiar error cuando un spaceId no se encuentra, a http 404

### DIFF
--- a/libs/design-projects/src/quotations/dto/create-quotation.dto.ts
+++ b/libs/design-projects/src/quotations/dto/create-quotation.dto.ts
@@ -190,7 +190,12 @@ export class CreateQuotationDto {
     description:
       'Array of Levels to create and link with this quotation. If empty, wont create any level',
     required: false,
-    example: [{ name: 'aaa', spaces: [] }],
+    example: [
+      {
+        name: 'primer nivel',
+        spaces: [{ amount: 2, area: 25.0, spaceId: 'aaaa-bbbb-ccc' }],
+      },
+    ],
   })
   @IsArray()
   @ValidateNested({ each: true })

--- a/libs/design-projects/src/quotations/quotations.service.ts
+++ b/libs/design-projects/src/quotations/quotations.service.ts
@@ -83,7 +83,7 @@ export class QuotationsService {
         this.logger.error(
           `create: attempted to create with an invalid spaceId`,
         );
-        throw new BadRequestException('Error creating quotaion');
+        throw new NotFoundException('Space not found');
       }
 
       // create the quotation along with its associated levels


### PR DESCRIPTION
- Al crear una cotizacion, cuando uno de los spaceId no se encuentran, el error lanzado ahora es NotFound en vez de BadRequest
- Agregar ejemplo del esquema de Spaces al DTO para crear cotizacion