### PR TITLE
feat: agregar codigo de cotizacion a prisma y pdf

### DIFF
--- a/libs/clients/src/interfaces/quotation.interface.ts
+++ b/libs/clients/src/interfaces/quotation.interface.ts
@@ -52,6 +52,7 @@ export type QuotationDataNested = Pick<
   | 'sanitaryCost'
   | 'metering'
   | 'createdAt'
+  | 'publicCode'
 > & {
   client: { id: string; name: string };
   levels: Array<LevelData>;

--- a/libs/design-projects/src/quotations/quotations.service.ts
+++ b/libs/design-projects/src/quotations/quotations.service.ts
@@ -1,8 +1,6 @@
 import {
   BadRequestException,
-  forwardRef,
   HttpStatus,
-  Inject,
   Injectable,
   InternalServerErrorException,
   Logger,
@@ -25,7 +23,6 @@ import {
 } from '@clients/clients/interfaces/quotation.interface';
 import * as Puppeteer from 'puppeteer';
 import { QuotationTemplate } from './quotations.template';
-import { LevelsService } from '../levels/levels.service';
 
 @Injectable()
 export class QuotationsService {
@@ -35,8 +32,6 @@ export class QuotationsService {
     private readonly audit: AuditService,
     private readonly clientService: ClientsService,
     private readonly template: QuotationTemplate,
-    @Inject(forwardRef(() => LevelsService))
-    private readonly levelsService: LevelsService,
   ) {}
 
   /**
@@ -330,6 +325,7 @@ export class QuotationsService {
         id: true,
         name: true,
         code: true,
+        publicCode: true,
         description: true,
         status: true,
         discount: true,
@@ -381,6 +377,7 @@ export class QuotationsService {
       id: quotation.id,
       name: quotation.name,
       code: quotation.code,
+      publicCode: quotation.publicCode,
       description: quotation.description,
       status: quotation.status,
       discount: quotation.discount,

--- a/libs/design-projects/src/quotations/quotations.template.tsx
+++ b/libs/design-projects/src/quotations/quotations.template.tsx
@@ -84,6 +84,7 @@ export class QuotationTemplate {
         <div class="px-16">
           <QuotationTemplate.header
             quotationCode={quotation.code}
+            quotationPublicCode={quotation.publicCode}
             quotationVersion={quotationVersion}
             quotationCreatedAt={quotation.createdAt}
           />
@@ -118,13 +119,20 @@ export class QuotationTemplate {
 
   private static header({
     quotationCode,
+    quotationPublicCode,
     quotationVersion,
     quotationCreatedAt,
   }: {
     quotationCode: string;
+    quotationPublicCode: number;
     quotationVersion: number;
     quotationCreatedAt: Date;
   }) {
+    const paddedQuotationCodeNumber = quotationPublicCode
+      .toString()
+      .padStart(3, '0');
+    const formattedQuotationCode = `COT-DIS-${paddedQuotationCodeNumber}`;
+
     return (
       <header class="border-2 border-black grid grid-cols-[4fr_6fr_4fr]">
         <div>Logo</div>
@@ -132,9 +140,13 @@ export class QuotationTemplate {
           Cotización
         </div>
         <div class="grid grid-cols-2 text-center text-sm font-bold">
-          <div class="border-b border-r border-black">Código</div>
+          <div class="border-b border-r border-black">Código de doc.</div>
           <div class="border-b border-black" safe>
             {quotationCode}
+          </div>
+          <div class="border-b border-r border-black">Código de cot.</div>
+          <div class="border-b border-black" safe>
+            {formattedQuotationCode}
           </div>
           <div class="border-b border-r border-black">Versión</div>
           <div class="border-b border-black">{quotationVersion}</div>

--- a/prisma/migrations/20241107142334_quotation_autoincrement_code/migration.sql
+++ b/prisma/migrations/20241107142334_quotation_autoincrement_code/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Quotation" ADD COLUMN     "publicCode" SERIAL NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model User {
   auditsPerformed Audit[] @relation("AuditPerformedBy")
 
   // Relación con UserRol
-  userRols  UserRol[]   @relation("UserId")
+  userRols UserRol[] @relation("UserId")
 
   @@unique([email, isActive])
 }
@@ -182,7 +182,12 @@ model BusinessConfig {
 
 // Tabla de cotizaciones (Quotation)
 model Quotation {
-  id          String @id @unique @default(uuid()) // Clave primaria
+  id String @id @unique @default(uuid()) // Clave primaria
+
+  // Un número autoincrementable que se muestra en el PDF de la cotizacion
+  // TRAZ-140
+  publicCode Int @default(autoincrement())
+
   name        String @default("SGC-P-04-F3") // Nombre del proyecto
   description String @default("") // Descripcion del proyecto. Ejm: "Se planifica diseño de una vivienda multifamiliar..."
   code        String // Código de la cotizacion.


### PR DESCRIPTION
- Modificar schema en prisma: agregar campo `publicCode` a tabla `Quotation` para almacenar el nro de cotizacion
- `publicCode` es autoincrementable
- ajustar interfaces, DTO y service para `publicCode`
- renderizar el código de documento y código de cotizacion en PDF