### PR TITLE
Fix/get by id workitem budget

### DIFF
--- a/libs/project-execution/src/budget/budget.service.ts
+++ b/libs/project-execution/src/budget/budget.service.ts
@@ -648,7 +648,7 @@ export class BudgetService {
                       const workItemName =
                         await this.prisma.workItem.findUnique({
                           where: { id: workItem.workItemId },
-                          select: { name: true },
+                          select: { name: true, unit: true },
                         });
 
                       const subWorkItems = await Promise.all(
@@ -661,12 +661,13 @@ export class BudgetService {
                             const subWorkItemName =
                               await this.prisma.subWorkItem.findUnique({
                                 where: { id: subWorkItem.subWorkItemId },
-                                select: { name: true },
+                                select: { name: true, unit: true },
                               });
 
                             return {
                               id: subWorkItem.id,
                               name: subWorkItemName?.name || '',
+                              unit: subWorkItemName?.unit || '',
                               quantity: subWorkItem.quantity,
                               unitCost: subWorkItem.unitCost,
                               subtotal: subWorkItem.subtotal,
@@ -677,12 +678,14 @@ export class BudgetService {
                       return {
                         id: workItem.id,
                         name: workItemName?.name || '',
+                        unit: workItemName?.unit || '',
                         quantity: workItem.quantity,
                         unitCost: workItem.unitCost,
                         subtotal: workItem.subtotal,
                         subWorkItems: subWorkItems.map((subWorkItem) => ({
                           id: subWorkItem.id,
                           name: subWorkItem.name,
+                          unit: subWorkItem.unit,
                           quantity: subWorkItem.quantity,
                           unitCost: subWorkItem.unitCost,
                           subtotal: subWorkItem.subtotal,

--- a/libs/project-execution/src/interfaces/budget.interfaces.ts
+++ b/libs/project-execution/src/interfaces/budget.interfaces.ts
@@ -29,6 +29,7 @@ export type CategoryBudgetDetails = {
     workitem: {
       id: string;
       name: string;
+      unit: string;
       quantity: number;
       unitCost: number;
       subtotal: number;


### PR DESCRIPTION
Solución a errores de get by id de work item para que si es que no hay apu lo mande en vacio el array.
Agregar unit a la función getById de budget para mostrarlo en categorias.